### PR TITLE
CppCheck Fix, use volumes instead of bind mounts

### DIFF
--- a/modules/devcontainers.psm1
+++ b/modules/devcontainers.psm1
@@ -150,27 +150,35 @@ function Start-DevContainer
         
         If the development container already exists, it is used, otherwise a new one is created.
 
+        If the volumes associated to the development container exist, they are used, otherwise they are created.
+
     .PARAMETER DevcontainerFile
         Path to the 'devcontainer.json' file. This is usually in the '.devcontainer' directory.
 
     .PARAMETER ProjectName
         The name of the compose project to start.
 
+    .PARAMETER VolumeInitScript
+        The initialization script for the volume associated to the 'vscode' service with the workspace, this script
+        only runs when the volume is empty.
+        
+        This script can be used for example to clone the target repository.
+
     .PARAMETER Inputs
-        Input artifacts that will be copied accross prior to building images, they follow the format:
+        Input artifacts that will be copied accross after starting the development container, they follow the format:
 
         @{
             "input_1" = @{
-                "srcPath" = "/path/to/source";
-                "destPath" = "/path/to/dest/";
+                "hostPath" = "/path/to/source";
+                "workspacePath" = "relative_path/to/dest/";
             };
             "input_2" = @{
-                "srcPath" = "/path/to/source";
-                "destPath" = "/path/to/dest";
+                "hostPath" = "/path/to/source";
+                "workspacePath" = "relative_path/to/dest";
             };
         }
 
-        The 'destPath' must be a path in the build context of the services to build.
+        The 'workspacePath' is relative to the workspace folder.
 
     .OUTPUTS
         This function does not return a value.
@@ -187,6 +195,9 @@ function Start-DevContainer
         [String]
         $ProjectName,
         [Parameter(Mandatory = $false)]
+        [String]
+        $VolumeInitScript,
+        [Parameter(Mandatory = $false)]
         [hashtable]
         $Inputs
     )
@@ -195,16 +206,6 @@ function Start-DevContainer
     if (-not (Test-Path "$DevcontainerFile"))
     {
         throw "'$DevcontainerFile' file does not exist.";
-    }
-
-    # Handle input artifacts.
-    if ($PSBoundParameters.ContainsKey("Inputs"))
-    {
-        foreach ($key in $Inputs.Keys)
-        {
-            Write-Log "Copying input artifact '$key'...";
-            New-CopyItem -Source "$($Inputs.$key.srcPath)" -Destination "$($Inputs.$key.destPath)";
-        }
     }
 
     # Use 'docker-compose' rather than the devcontainer CLI to create the development container, as the latter does not
@@ -223,11 +224,53 @@ function Start-DevContainer
     {
         throw "Failed to start development container with error '$error'.";
     }
+    
+    # Get the workspace folder from the 'devcontainer.json' file.
+    $workspaceFolder = (New-JSONC -JSONCPath "$DevcontainerFile").workspaceFolder;
+    if ($workspaceFolder.Length -eq 0)
+    {
+        throw "The field 'workspaceFolder' must be specified in '$DevcontainerFile'.";
+    }
+
+    # Handle initialization script.
+    if ($PSBoundParameters.ContainsKey("VolumeInitScript"))
+    {
+        # Determine if the 'vscode' volume, is empty or not before running the initialization script.
+        $isEmpty = (& "docker-compose" --project-name "$ProjectName" exec --workdir "$workspaceFolder" "vscode" `
+            pwsh -Command 'ls').Length -eq 0;
+        if ($isEmpty)
+        {
+            # Since the workspace is empty, run the initialization script.
+            Write-Log "Running initialization script for 'vscode' volume...";
+            & "docker-compose" --project-name "$ProjectName" exec --workdir "$workspaceFolder" "vscode" pwsh -Command `
+                "$VolumeInitScript";
+            if ($LASTEXITCODE -ne 0)
+            {
+                throw "Initialization script for volume failed with error '$LASTEXITCODE'.";
+            }
+        }
+    }
+
+    # Handle input artifacts.
+    if ($PSBoundParameters.ContainsKey("Inputs"))
+    {
+        foreach ($key in $Inputs.Keys)
+        {
+            Write-Log "Copying input artifact '$key' from host to container...";
+            & "docker" cp `
+                "$($Inputs.$key.hostPath)" `
+                "$($vscodeContainerID):$workspaceFolder/$($Inputs.$key.workspacePath)";
+            if ($LASTEXITCODE -ne 0)
+            {
+                throw "Failed to copy artifact from host to development container with error '$LASTEXITCODE'.";
+            }
+        }
+    }
 
     # Open development container.
     Write-Log "Opening folder '$PWD' in Visual Studio code and development container...";
     $env:COMPOSE_PROJECT_NAME = $ProjectName;
-    & "devcontainer" open "$PWD" --disable-telemetry;
+    & "devcontainer" open "$PWD" --config "$DevcontainerFile" --disable-telemetry;
     $env:COMPOSE_PROJECT_NAME = $null;
 }
 

--- a/modules/linters.psm1
+++ b/modules/linters.psm1
@@ -213,13 +213,17 @@ function Start-CppCheck
     }
     Write-Log "Finished running CppCheck HTML report." "Success";
 
+    # Get contents of the XML file, some errors are not reported as errors, but rather as warnings, not returning
+    # an error on exit.
+    $errCount = ([xml](Get-Content -Path "$outputXMLFile")).results.errors.error.Count;
+
     # Check if CppCheck found errors, and in that case report them.
-    if ($cppCheckLastExitCode -ne 0)
+    if (($cppCheckLastExitCode -ne 0) -or ($errCount -ne 0))
     {
         # On error, print the errors, the contents of the XML file, to the standard output, as CppCheck does not
-	# print anything to the standard output when it finds errors if generating XML.
+        # print anything to the standard output when it finds errors if generating XML.
         Get-Content -Path "$outputXMLFile" | Write-Output;
-        throw "CppCheck finished with error '$LASTEXITCODE', check output for details.";
+        throw "CppCheck finished with error '$cppCheckLastExitCode' and '$errCount' errors, check output for details.";
     }
     Write-Log "Finished running CppCheck, no errors found." "Success";
 }

--- a/readme.rst
+++ b/readme.rst
@@ -12,6 +12,3 @@ The `modules` folder contains:
 - *tests.psm1*, functionality related to test and coverage tools such as *fastcov*, *cmocka* or *junit2html*.
 - *devcontainers.psm1*, functionality related to *docker*, *docker-compose*, *vscode* and *devcontainers*.
 - *commons.psm1*, functionality common to all modules or that does not fit anywhere else.
-
-This repository is meant to be included as a submodule by other repositories making use of these scripts, and the
-scripts meant to be run from the root directory of the parent repository.


### PR DESCRIPTION
- Fix CppCheck function that would not report warnings as errors.
- Make `Start-DevContainer` work with volumes rather than bind mounts, as the former is much faster in terms of I/O.
