### PR TITLE
Release 1.3.0

### DIFF
--- a/modules/devcontainers.psm1
+++ b/modules/devcontainers.psm1
@@ -231,7 +231,7 @@ function Start-DevContainer
     # Determine if the 'vscode' volume, is empty or not before copying the artifacts and running the
     # initialization script, if it is already initialized, then skip this step.
     $isInitialized = (& "docker-compose" --project-name "$ProjectName" exec --workdir "$workspaceFolder" "vscode" `
-        pwsh -Command "ls").Length -gt 0;
+            pwsh -Command "ls").Length -gt 0;
     if (-not ($isInitialized))
     {
         # Handle input artifacts.


### PR DESCRIPTION
- Add compilation database processing in _Start-ClangTidy_.
- Add compilation database processing in _Start-DoxygenSphinx_.
- Change _Start-ClangFormat_ so that it does not rely on a external file.
- Add function to obtain a compilation database from a _compilation_commands.json_ file.