### PR TITLE
Allow missing source on genhtml

### DIFF
--- a/modules/tests.psm1
+++ b/modules/tests.psm1
@@ -252,6 +252,7 @@ function Start-FastCov
         --header-title "Coverage Report" `
         --footer "" `
         --no-sort `
+        --ignore-errors source `
         "$(Join-Path -Path "$CoverageDir" -ChildPath "!coverage.info")";
     if ($LASTEXITCODE -ne 0)
     {


### PR DESCRIPTION
- Allow missing sources, for example, when tests are generated from templates via compilation defines and the source does not explicitly exist.