### PR TITLE
Add no unknown warning in Clang Tidy as extra argument

### DIFF
--- a/modules/linters.psm1
+++ b/modules/linters.psm1
@@ -307,7 +307,7 @@ function Start-ClangTidy
 
     Write-Log "Running clang-tidy...";
     & "$ClangTidyExe" -p="$CMakeBuildDir" --config-file="$ConfigFile" `
-        --extra-arg "-Wno-unused-command-line-argument" @allFiles;
+        --extra-arg "-Wno-unused-command-line-argument" --extra-arg "-Wno-unknown-warning-option" @allFiles;
     if ($LASTEXITCODE -ne 0)
     {
         throw "clang-tidy finished with error '$LASTEXITCODE', check output for details.";


### PR DESCRIPTION
- If a compilation flag is not recognized in clang-tidy because, for example, GCC was used for compilation, just ignore it rather than raising a warning that can end up as an error.